### PR TITLE
Fix crash in CMaterials::SetColor when pMaterial or I::RenderView is null

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -23,11 +23,7 @@ jobs:
 
     - name: Build
       working-directory: ${{ env.GITHUB_WORKSPACE }}
-      run: |
-        msbuild Amalgam.sln /p:Platform=${{ matrix.platform }} /p:Configuration=${{ matrix.configuration }} ^
-          /p:DebugType=full ^
-          /p:GenerateDebugInformation=true ^
-          /p:GenerateMapFile=true
+      run: msbuild Amalgam.sln /p:Platform=${{ matrix.platform }} /p:Configuration=${{ matrix.configuration }} /p:DebugType=full /p:GenerateDebugInformation=true /p:GenerateMapFile=true
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -21,21 +21,51 @@ jobs:
       working-directory: ${{ env.GITHUB_WORKSPACE }}
       run: nuget restore
 
-    - name: Build
+    - name: Build with debug info and map generation
       working-directory: ${{ env.GITHUB_WORKSPACE }}
-      run: msbuild Amalgam.sln /p:Platform=${{ matrix.platform }} /p:Configuration=${{ matrix.configuration }} /p:DebugType=full /p:GenerateDebugInformation=true /p:GenerateMapFile=true
+      run: |
+        msbuild Amalgam.sln /p:Platform=${{ matrix.platform }} /p:Configuration=${{ matrix.configuration }} ^
+          /p:DebugType=full ^
+          /p:GenerateDebugInformation=true ^
+          /p:GenerateMapFile=true ^
+          /p:LinkerAdditionalOptions="/MAP"
 
-    - uses: actions/upload-artifact@v4
+    - name: List all build outputs (debug)
+      run: |
+        Write-Host "=== Searching for .pdb and .map files ==="
+        Get-ChildItem -Recurse -Include *.pdb, *.map, *.dll, *.exe | ForEach-Object { Write-Host $_.FullName }
+
+    - name: Upload DLLs
+      uses: actions/upload-artifact@v4
       with:
         name: Amalgam${{ matrix.platform }}${{ matrix.configuration }}
-        path: output/${{ matrix.platform }}/${{ matrix.configuration }}/*.dll
+        path: |
+          output/${{ matrix.platform }}/${{ matrix.configuration }}/*.dll
+          **/bin/${{ matrix.platform }}/${{ matrix.configuration }}/*.dll
 
-    - uses: actions/upload-artifact@v4
+    - name: Upload PDBs
+      uses: actions/upload-artifact@v4
       with:
         name: Amalgam${{ matrix.platform }}${{ matrix.configuration }}PDB
-        path: output/${{ matrix.platform }}/${{ matrix.configuration }}/*.pdb
+        path: |
+          output/${{ matrix.platform }}/${{ matrix.configuration }}/*.pdb
+          **/bin/${{ matrix.platform }}/${{ matrix.configuration }}/*.pdb
 
-    - uses: actions/upload-artifact@v4
+    - name: Upload MAP files (if any)
+      uses: actions/upload-artifact@v4
       with:
         name: Amalgam${{ matrix.platform }}${{ matrix.configuration }}Map
-        path: output/${{ matrix.platform }}/${{ matrix.configuration }}/*.map
+        path: |
+          output/${{ matrix.platform }}/${{ matrix.configuration }}/*.map
+          **/bin/${{ matrix.platform }}/${{ matrix.configuration }}/*.map
+          **/*.map
+        if-no-files-found: warn   # don't fail if no maps
+
+    - name: Upload all other build artifacts (for fallback)
+      uses: actions/upload-artifact@v4
+      with:
+        name: Amalgam${{ matrix.platform }}${{ matrix.configuration }}FullBuild
+        path: |
+          output/
+          **/bin/
+        if-no-files-found: warn

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -23,14 +23,23 @@ jobs:
 
     - name: Build
       working-directory: ${{ env.GITHUB_WORKSPACE }}
-      run: msbuild Amalgam.sln /p:Platform=${{ matrix.platform }} /p:Configuration=${{ matrix.configuration }}
-    
+      run: |
+        msbuild Amalgam.sln /p:Platform=${{ matrix.platform }} /p:Configuration=${{ matrix.configuration }} ^
+          /p:DebugType=full ^
+          /p:GenerateDebugInformation=true ^
+          /p:GenerateMapFile=true
+
     - uses: actions/upload-artifact@v4
       with:
         name: Amalgam${{ matrix.platform }}${{ matrix.configuration }}
         path: output/${{ matrix.platform }}/${{ matrix.configuration }}/*.dll
-    
+
     - uses: actions/upload-artifact@v4
       with:
         name: Amalgam${{ matrix.platform }}${{ matrix.configuration }}PDB
         path: output/${{ matrix.platform }}/${{ matrix.configuration }}/*.pdb
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: Amalgam${{ matrix.platform }}${{ matrix.configuration }}Map
+        path: output/${{ matrix.platform }}/${{ matrix.configuration }}/*.map

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -23,12 +23,7 @@ jobs:
 
     - name: Build with debug info and map generation
       working-directory: ${{ env.GITHUB_WORKSPACE }}
-      run: |
-        msbuild Amalgam.sln /p:Platform=${{ matrix.platform }} /p:Configuration=${{ matrix.configuration }} ^
-          /p:DebugType=full ^
-          /p:GenerateDebugInformation=true ^
-          /p:GenerateMapFile=true ^
-          /p:LinkerAdditionalOptions="/MAP"
+      run: msbuild Amalgam.sln /p:Platform=${{ matrix.platform }} /p:Configuration=${{ matrix.configuration }} /p:DebugType=full /p:GenerateDebugInformation=true /p:GenerateMapFile=true /p:LinkerAdditionalOptions="/MAP"
 
     - name: List all build outputs (debug)
       run: |
@@ -42,6 +37,7 @@ jobs:
         path: |
           output/${{ matrix.platform }}/${{ matrix.configuration }}/*.dll
           **/bin/${{ matrix.platform }}/${{ matrix.configuration }}/*.dll
+          **/x64/ReleaseAVX2/*.dll   # Fallback common paths
 
     - name: Upload PDBs
       uses: actions/upload-artifact@v4
@@ -50,6 +46,7 @@ jobs:
         path: |
           output/${{ matrix.platform }}/${{ matrix.configuration }}/*.pdb
           **/bin/${{ matrix.platform }}/${{ matrix.configuration }}/*.pdb
+          **/x64/ReleaseAVX2/*.pdb
 
     - name: Upload MAP files (if any)
       uses: actions/upload-artifact@v4
@@ -59,13 +56,14 @@ jobs:
           output/${{ matrix.platform }}/${{ matrix.configuration }}/*.map
           **/bin/${{ matrix.platform }}/${{ matrix.configuration }}/*.map
           **/*.map
-        if-no-files-found: warn   # don't fail if no maps
+        if-no-files-found: warn
 
-    - name: Upload all other build artifacts (for fallback)
+    - name: Upload full build folder (fallback)
       uses: actions/upload-artifact@v4
       with:
         name: Amalgam${{ matrix.platform }}${{ matrix.configuration }}FullBuild
         path: |
           output/
           **/bin/
+          **/x64/
         if-no-files-found: warn

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -21,49 +21,16 @@ jobs:
       working-directory: ${{ env.GITHUB_WORKSPACE }}
       run: nuget restore
 
-    - name: Build with debug info and map generation
+    - name: Build
       working-directory: ${{ env.GITHUB_WORKSPACE }}
-      run: msbuild Amalgam.sln /p:Platform=${{ matrix.platform }} /p:Configuration=${{ matrix.configuration }} /p:DebugType=full /p:GenerateDebugInformation=true /p:GenerateMapFile=true /p:LinkerAdditionalOptions="/MAP"
-
-    - name: List all build outputs (debug)
-      run: |
-        Write-Host "=== Searching for .pdb and .map files ==="
-        Get-ChildItem -Recurse -Include *.pdb, *.map, *.dll, *.exe | ForEach-Object { Write-Host $_.FullName }
-
-    - name: Upload DLLs
-      uses: actions/upload-artifact@v4
+      run: msbuild Amalgam.sln /p:Platform=${{ matrix.platform }} /p:Configuration=${{ matrix.configuration }}
+    
+    - uses: actions/upload-artifact@v4
       with:
         name: Amalgam${{ matrix.platform }}${{ matrix.configuration }}
-        path: |
-          output/${{ matrix.platform }}/${{ matrix.configuration }}/*.dll
-          **/bin/${{ matrix.platform }}/${{ matrix.configuration }}/*.dll
-          **/x64/ReleaseAVX2/*.dll   # Fallback common paths
-
-    - name: Upload PDBs
-      uses: actions/upload-artifact@v4
+        path: output/${{ matrix.platform }}/${{ matrix.configuration }}/*.dll
+    
+    - uses: actions/upload-artifact@v4
       with:
         name: Amalgam${{ matrix.platform }}${{ matrix.configuration }}PDB
-        path: |
-          output/${{ matrix.platform }}/${{ matrix.configuration }}/*.pdb
-          **/bin/${{ matrix.platform }}/${{ matrix.configuration }}/*.pdb
-          **/x64/ReleaseAVX2/*.pdb
-
-    - name: Upload MAP files (if any)
-      uses: actions/upload-artifact@v4
-      with:
-        name: Amalgam${{ matrix.platform }}${{ matrix.configuration }}Map
-        path: |
-          output/${{ matrix.platform }}/${{ matrix.configuration }}/*.map
-          **/bin/${{ matrix.platform }}/${{ matrix.configuration }}/*.map
-          **/*.map
-        if-no-files-found: warn
-
-    - name: Upload full build folder (fallback)
-      uses: actions/upload-artifact@v4
-      with:
-        name: Amalgam${{ matrix.platform }}${{ matrix.configuration }}FullBuild
-        path: |
-          output/
-          **/bin/
-          **/x64/
-        if-no-files-found: warn
+        path: output/${{ matrix.platform }}/${{ matrix.configuration }}/*.pdb

--- a/Amalgam/src/Features/Visuals/Materials/Materials.cpp
+++ b/Amalgam/src/Features/Visuals/Materials/Materials.cpp
@@ -254,22 +254,22 @@ void CMaterials::ReloadMaterials()
 
 void CMaterials::SetColor(Material_t* pMaterial, Color_t tColor)
 {
-	float r = tColor.r / 255.f;
-	float g = tColor.g / 255.f;
-	float b = tColor.b / 255.f;
-	float a = tColor.a / 255.f;
+    if (!pMaterial || !I::RenderView)
+        return;
 
-	I::RenderView->SetColorModulation(r, g, b);
-	I::RenderView->SetBlend(a);
+    float r = tColor.r / 255.f;
+    float g = tColor.g / 255.f;
+    float b = tColor.b / 255.f;
+    float a = tColor.a / 255.f;
 
-	if (pMaterial)
-	{
-		StoreVars(*pMaterial);
-		if (pMaterial->m_phongtint)
-			pMaterial->m_phongtint->SetVecValue(r, g, b);
-		if (pMaterial->m_envmaptint)
-			pMaterial->m_envmaptint->SetVecValue(r, g, b);
-	}
+    I::RenderView->SetColorModulation(r, g, b);
+    I::RenderView->SetBlend(a);
+
+    StoreVars(*pMaterial);
+    if (pMaterial->m_phongtint)
+        pMaterial->m_phongtint->SetVecValue(r, g, b);
+    if (pMaterial->m_envmaptint)
+        pMaterial->m_envmaptint->SetVecValue(r, g, b);
 }
 
 


### PR DESCRIPTION
Fixes ACCESS_VIOLATION (0xC0000005) crash when SetColor is called with null pMaterial or I::RenderView. Adds necessary null checks before dereferencing.